### PR TITLE
Add Emulator Configuration Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,11 @@ The tool provides the following operations on hacks
 The tab with the gear icon allows to modify global settings. Their names should
 be pretty self-explanatory.
 
+By default, the tool will open SFC file with the default app specified in the
+operating system. It's possible to specify a custom emulator path and arguments
+via settings. This is especially useful when using RetroArch, which requires
+opening files with the `-L` flag.
+
 You can also specify a custom cookie that will be used for search and downloads,
 to bypass CAPTCHAs.
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2589,6 +2589,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "shell-words",
  "tauri",
  "tauri-build",
  "tauri-plugin-fs-watch",
@@ -2877,6 +2878,12 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "simd-adler32"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1.0"
 open = "4"
 reqwest = "0.11.16"
 zip-extract = "0.1.2"
+shell-words = "1.1.0"
 
 
 [features]

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -114,12 +114,12 @@ fn open_with_default_app(path: &str) -> Result<(), String> {
 
 #[tauri::command]
 fn open_with_selected_app(file_path: &str, emulator_path: &str, args: &str) -> Result<(), String> {
-  let args_vec: Vec<&str> = args.split_whitespace().collect(); // Split the args into a vector
+  let args_vec: Vec<&str> = args.split_whitespace().collect();
   let mut command = std::process::Command::new(emulator_path);
   for arg in args_vec {
-      command.arg(arg); // Add each argument separately
+      command.arg(arg);
   }
-  command.arg(file_path); // Then, add the file path
+  command.arg(file_path);
   command.spawn()
       .map_err(|e| e.to_string())?;
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -113,6 +113,20 @@ fn open_with_default_app(path: &str) -> Result<(), String> {
 }
 
 #[tauri::command]
+fn open_with_selected_app(file_path: &str, emulator_path: &str, args: &str) -> Result<(), String> {
+  let args_vec: Vec<&str> = args.split_whitespace().collect(); // Split the args into a vector
+  let mut command = std::process::Command::new(emulator_path);
+  for arg in args_vec {
+      command.arg(arg); // Add each argument separately
+  }
+  command.arg(file_path); // Then, add the file path
+  command.spawn()
+      .map_err(|e| e.to_string())?;
+
+  Ok(())
+}
+
+#[tauri::command]
 async fn download_hack(
   app_handle: tauri::AppHandle,
   game_directory: &str,
@@ -126,6 +140,7 @@ async fn download_hack(
     Err(e) => return Err(e),
     _ => (),
   }
+  
 
   // Validate Vanilla ROM
   match validate_file_path(game_original_copy) {
@@ -233,6 +248,7 @@ fn main() {
     .invoke_handler(tauri::generate_handler![
       download_hack,
       open_with_default_app,
+      open_with_selected_app,
       path_exists,
       validate_directory_path,
       validate_file_path,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -114,9 +114,12 @@ fn open_with_default_app(path: &str) -> Result<(), String> {
 
 #[tauri::command]
 fn open_with_selected_app(file_path: &str, emulator_path: &str, emulator_args: &str) -> Result<(), String> {
-  let args_vec: Vec<&str> = emulator_args.split_whitespace().collect();
+  let args = match shell_words::split(emulator_args) {
+    Err(_) => return Err("Failed to parse emulator arguments".into()),
+    Ok(a) => a
+  };
   let mut command = std::process::Command::new(emulator_path);
-  for arg in args_vec {
+  for arg in args {
       command.arg(arg);
   }
   command.arg(file_path);

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -113,8 +113,8 @@ fn open_with_default_app(path: &str) -> Result<(), String> {
 }
 
 #[tauri::command]
-fn open_with_selected_app(file_path: &str, emulator_path: &str, args: &str) -> Result<(), String> {
-  let args_vec: Vec<&str> = args.split_whitespace().collect();
+fn open_with_selected_app(file_path: &str, emulator_path: &str, emulator_args: &str) -> Result<(), String> {
+  let args_vec: Vec<&str> = emulator_args.split_whitespace().collect();
   let mut command = std::process::Command::new(emulator_path);
   for arg in args_vec {
       command.arg(arg);
@@ -140,7 +140,7 @@ async fn download_hack(
     Err(e) => return Err(e),
     _ => (),
   }
-  
+
 
   // Validate Vanilla ROM
   match validate_file_path(game_original_copy) {

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -113,14 +113,6 @@ fn open_with_default_app(path: &str) -> Result<(), String> {
 }
 
 #[tauri::command]
-fn select_emulator_path() -> Result<String, String> {
-  tauri::api::dialog::blocking::FileDialogBuilder::new()
-    .pick_file()
-    .map(|path_buf| path_buf.to_string_lossy().into_owned())
-    .ok_or_else(|| "No file selected".to_string())
-}
-
-#[tauri::command]
 async fn download_hack(
   app_handle: tauri::AppHandle,
   game_directory: &str,
@@ -241,7 +233,6 @@ fn main() {
     .invoke_handler(tauri::generate_handler![
       download_hack,
       open_with_default_app,
-      select_emulator_path,
       path_exists,
       validate_directory_path,
       validate_file_path,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -113,6 +113,14 @@ fn open_with_default_app(path: &str) -> Result<(), String> {
 }
 
 #[tauri::command]
+fn select_emulator_path() -> Result<String, String> {
+  tauri::api::dialog::blocking::FileDialogBuilder::new()
+    .pick_file()
+    .map(|path_buf| path_buf.to_string_lossy().into_owned())
+    .ok_or_else(|| "No file selected".to_string())
+}
+
+#[tauri::command]
 async fn download_hack(
   app_handle: tauri::AppHandle,
   game_directory: &str,
@@ -233,6 +241,7 @@ fn main() {
     .invoke_handler(tauri::generate_handler![
       download_hack,
       open_with_default_app,
+      select_emulator_path,
       path_exists,
       validate_directory_path,
       validate_file_path,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -120,9 +120,8 @@ fn open_with_selected_app(file_path: &str, emulator_path: &str, emulator_args: &
   };
   let mut command = std::process::Command::new(emulator_path);
   for arg in args {
-      command.arg(arg);
+      command.arg(if arg == "%1" { file_path } else { &arg });
   }
-  command.arg(file_path);
   command.spawn()
       .map_err(|e| e.to_string())?;
 

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -11,6 +11,7 @@ export type ButtonProps = {
   rightIcon?: CButtonProps["rightIcon"];
   text: string;
   variant?: CButtonProps["variant"];
+  colorScheme?: CButtonProps["colorScheme"];
 };
 
 function Button({
@@ -21,11 +22,12 @@ function Button({
   rightIcon,
   text,
   variant,
+  colorScheme = "blue",
 }: ButtonProps) {
   return (
     <CButton
       borderRadius={0}
-      colorScheme="blue"
+      colorScheme={colorScheme}
       leftIcon={leftIcon}
       isDisabled={isDisabled}
       isLoading={isLoading}

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -19,6 +19,7 @@ export type TextEditorProps = {
   placeholder: string;
   type?: InputProps["type"];
   value: string;
+  isReadOnly?: boolean;
 };
 
 function TextEditor({
@@ -31,6 +32,7 @@ function TextEditor({
   placeholder,
   type,
   value,
+  isReadOnly = false,
 }: TextEditorProps) {
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -65,6 +67,7 @@ function TextEditor({
         placeholder={placeholder}
         type={type}
         value={value}
+        isReadOnly={isReadOnly}
       />
 
       {error && (

--- a/src/windows/main/PanelGlobalSettings.tsx
+++ b/src/windows/main/PanelGlobalSettings.tsx
@@ -1,32 +1,13 @@
 import { Flex, Text } from "@chakra-ui/react";
-import Button from "../../components/Button";
 import Checkbox from "../../components/Checkbox";
 import Panel from "../../components/Panel";
+import PathBrowser from "../../components/PathBrowser";
 import Section from "../../components/Section";
 import TextEditor from "../../components/TextEditor";
 import { useGlobalSettings } from "../store";
-import useTauriInvoke from "../../hooks/useTauriInvoke";
-import { invoke } from "@tauri-apps/api";
 
 function PanelGlobalSettings() {
   const [globalSettings, globalSettingsMethods] = useGlobalSettings();
-
-  const onSelectPathClick = async () => {
-    try {
-      const selectedPath = await invoke("select_emulator_path");
-      if (typeof selectedPath === "string") {
-        globalSettingsMethods.setEmulatorPath(selectedPath);
-      } else {
-        console.error("Selected path is not a string:", selectedPath);
-      }
-    } catch (error) {
-      console.error("Error selecting path:", error);
-    }
-  };
-
-  const onSelectedPathClear = () => {
-    globalSettingsMethods.setEmulatorPath("");
-  };
 
   return (
     <Panel>
@@ -60,20 +41,12 @@ function PanelGlobalSettings() {
             Set the path to your preferred emulator here. You can set optional
             command line arguments e.g. when using something like Retroarch
           </Text>
-          <Flex gap={2}>
-            <Button text="Select Path" onClick={onSelectPathClick} />
-            <TextEditor
-              value={globalSettings.emulatorPath}
-              onChange={() => console.log()}
-              placeholder="Path to your emulator"
-              isReadOnly
-            />
-            <Button
-              colorScheme="red"
-              text="Clear"
-              onClick={onSelectedPathClear}
-            />
-          </Flex>
+          <PathBrowser
+            mode="file"
+            onChange={globalSettingsMethods.setEmulatorPath}
+            value={globalSettings.emulatorPath}
+            placeholder="Emulator path"
+          />
           <Flex gap={2}>
             <TextEditor
               value={globalSettings.emulatorArguments}

--- a/src/windows/main/PanelGlobalSettings.tsx
+++ b/src/windows/main/PanelGlobalSettings.tsx
@@ -48,6 +48,7 @@ function PanelGlobalSettings() {
               value={globalSettings.emulatorArgs}
               onChange={globalSettingsMethods.setEmulatorArgs}
               placeholder="Command Line Arguments"
+              isDisabled={!globalSettings.emulatorPath.trim()}
             />
           </Flex>
         </Flex>

--- a/src/windows/main/PanelGlobalSettings.tsx
+++ b/src/windows/main/PanelGlobalSettings.tsx
@@ -1,12 +1,32 @@
 import { Flex, Text } from "@chakra-ui/react";
+import Button from "../../components/Button";
 import Checkbox from "../../components/Checkbox";
 import Panel from "../../components/Panel";
 import Section from "../../components/Section";
-import { useGlobalSettings } from "../store";
 import TextEditor from "../../components/TextEditor";
+import { useGlobalSettings } from "../store";
+import useTauriInvoke from "../../hooks/useTauriInvoke";
+import { invoke } from "@tauri-apps/api";
 
 function PanelGlobalSettings() {
   const [globalSettings, globalSettingsMethods] = useGlobalSettings();
+
+  const onSelectPathClick = async () => {
+    try {
+      const selectedPath = await invoke("select_emulator_path");
+      if (typeof selectedPath === "string") {
+        globalSettingsMethods.setEmulatorPath(selectedPath);
+      } else {
+        console.error("Selected path is not a string:", selectedPath);
+      }
+    } catch (error) {
+      console.error("Error selecting path:", error);
+    }
+  };
+
+  const onSelectedPathClear = () => {
+    globalSettingsMethods.setEmulatorPath("");
+  };
 
   return (
     <Panel>
@@ -31,6 +51,36 @@ function PanelGlobalSettings() {
             onChange={globalSettingsMethods.setOpenHackFolderAfterDownload}
             value={globalSettings.openHackFolderAfterDownload}
           />
+        </Flex>
+      </Section>
+
+      <Section isDefaultExpanded title="Emulator">
+        <Flex direction="column" gap={2}>
+          <Text fontSize="sm">
+            Set the path to your preferred emulator here. You can set optional
+            command line arguments e.g. when using something like Retroarch
+          </Text>
+          <Flex gap={2}>
+            <Button text="Select Path" onClick={onSelectPathClick} />
+            <TextEditor
+              value={globalSettings.emulatorPath}
+              onChange={() => console.log()}
+              placeholder="Path to your emulator"
+              isReadOnly
+            />
+            <Button
+              colorScheme="red"
+              text="Clear"
+              onClick={onSelectedPathClear}
+            />
+          </Flex>
+          <Flex gap={2}>
+            <TextEditor
+              value={globalSettings.emulatorArguments}
+              onChange={globalSettingsMethods.setEmulatorArguments}
+              placeholder="Arguments (optional)"
+            />
+          </Flex>
         </Flex>
       </Section>
 

--- a/src/windows/main/PanelGlobalSettings.tsx
+++ b/src/windows/main/PanelGlobalSettings.tsx
@@ -37,6 +37,12 @@ function PanelGlobalSettings() {
 
       <Section isDefaultExpanded title="Emulator">
         <Flex direction="column" gap={2}>
+          <Text fontSize="sm">
+            Use the field below to specify a custom emulator with which to open
+            ROMs. If nothing is specified, the default app specified in the
+            operating system for SFC files will be used. In the command line
+            arguments <b>%1</b> will be replaced with the ROM path.
+          </Text>
           <PathBrowser
             mode="file"
             onChange={globalSettingsMethods.setEmulatorPath}

--- a/src/windows/main/PanelGlobalSettings.tsx
+++ b/src/windows/main/PanelGlobalSettings.tsx
@@ -45,9 +45,9 @@ function PanelGlobalSettings() {
           />
           <Flex gap={2}>
             <TextEditor
-              placeholder="Command Line Arguments (optional)"
               value={globalSettings.emulatorArgs}
               onChange={globalSettingsMethods.setEmulatorArgs}
+              placeholder="Command Line Arguments"
             />
           </Flex>
         </Flex>

--- a/src/windows/main/PanelGlobalSettings.tsx
+++ b/src/windows/main/PanelGlobalSettings.tsx
@@ -45,9 +45,9 @@ function PanelGlobalSettings() {
           />
           <Flex gap={2}>
             <TextEditor
-              value={globalSettings.emulatorArguments}
-              onChange={globalSettingsMethods.setEmulatorArguments}
               placeholder="Command Line Arguments (optional)"
+              value={globalSettings.emulatorArgs}
+              onChange={globalSettingsMethods.setEmulatorArgs}
             />
           </Flex>
         </Flex>

--- a/src/windows/main/PanelGlobalSettings.tsx
+++ b/src/windows/main/PanelGlobalSettings.tsx
@@ -37,10 +37,6 @@ function PanelGlobalSettings() {
 
       <Section isDefaultExpanded title="Emulator">
         <Flex direction="column" gap={2}>
-          <Text fontSize="sm">
-            Set the path to your preferred emulator here. You can set optional
-            command line arguments e.g. when using something like Retroarch
-          </Text>
           <PathBrowser
             mode="file"
             onChange={globalSettingsMethods.setEmulatorPath}
@@ -51,7 +47,7 @@ function PanelGlobalSettings() {
             <TextEditor
               value={globalSettings.emulatorArguments}
               onChange={globalSettingsMethods.setEmulatorArguments}
-              placeholder="Arguments (optional)"
+              placeholder="Command Line Arguments (optional)"
             />
           </Flex>
         </Flex>

--- a/src/windows/main/SectionHacks.tsx
+++ b/src/windows/main/SectionHacks.tsx
@@ -84,7 +84,13 @@ function SectionHacks({ gameId }: SectionHacksProps) {
         icon: <Icon as={MdPlayCircle} />,
         label: "Play",
         onClick: (hack: Hack) =>
-          invoke("open_with_default_app", { path: hack.sfcPath }),
+          // invoke("open_with_selected_app", {
+          //   emulator_path: globalSettings.emulatorPath,
+          //   file_path: hack.sfcPath,
+          // }),
+          invoke("open_with_selected_app", {filePath: hack.sfcPath, emulatorPath: globalSettings.emulatorPath, args: globalSettings.emulatorArguments}),
+
+          // invoke("open_with_default_app", { path: hack.sfcPath }),
       },
       {
         icon: <Icon as={MdFolder} />,

--- a/src/windows/main/SectionHacks.tsx
+++ b/src/windows/main/SectionHacks.tsx
@@ -83,14 +83,17 @@ function SectionHacks({ gameId }: SectionHacksProps) {
       {
         icon: <Icon as={MdPlayCircle} />,
         label: "Play",
-        onClick: (hack: Hack) =>
-          // invoke("open_with_selected_app", {
-          //   emulator_path: globalSettings.emulatorPath,
-          //   file_path: hack.sfcPath,
-          // }),
-          invoke("open_with_selected_app", {filePath: hack.sfcPath, emulatorPath: globalSettings.emulatorPath, args: globalSettings.emulatorArguments}),
-
-          // invoke("open_with_default_app", { path: hack.sfcPath }),
+        onClick: (hack: Hack) => {
+          if (globalSettings.emulatorPath) {
+            invoke("open_with_selected_app", {
+              filePath: hack.sfcPath,
+              emulatorPath: globalSettings.emulatorPath,
+              args: globalSettings.emulatorArguments,
+            });
+          } else {
+            invoke("open_with_default_app", { path: hack.sfcPath });
+          }
+        },
       },
       {
         icon: <Icon as={MdFolder} />,

--- a/src/windows/main/SectionHacks.tsx
+++ b/src/windows/main/SectionHacks.tsx
@@ -88,7 +88,7 @@ function SectionHacks({ gameId }: SectionHacksProps) {
             invoke("open_with_selected_app", {
               filePath: hack.sfcPath,
               emulatorPath: globalSettings.emulatorPath,
-              args: globalSettings.emulatorArguments,
+              emulatorArgs: globalSettings.emulatorArgs,
             });
           } else {
             invoke("open_with_default_app", { path: hack.sfcPath });

--- a/src/windows/store.ts
+++ b/src/windows/store.ts
@@ -18,6 +18,8 @@ const GlobalSettingsSchema = z.object({
   askForConfirmationBeforeRemovingGame: z.boolean(),
   openHackFolderAfterDownload: z.boolean(),
   cookie: z.string(),
+  emulatorPath: z.string(),
+  emulatorArguments: z.string(),
 });
 
 const GameSchema = z.object({
@@ -59,6 +61,8 @@ const defaultGlobalSettings = {
   askForConfirmationBeforeRemovingGame: true,
   openHackFolderAfterDownload: false,
   cookie: "",
+  emulatorPath: "",
+  emulatorArguments: "",
 };
 
 const globalSettingsState = atom<GlobalSettings>({
@@ -120,6 +124,8 @@ export const useGlobalSettings = (): [
     setAskForConfirmationBeforeRemovingGame: (value: boolean) => void;
     setOpenHackFolderAfterDownload: (value: boolean) => void;
     setCookie: (value: string) => void;
+    setEmulatorPath: (value: string) => void;
+    setEmulatorArguments: (value: string) => void;
   }
 ] => {
   const [globalSettings, setGlobalSettings] =
@@ -161,6 +167,24 @@ export const useGlobalSettings = (): [
     [setGlobalSettings]
   );
 
+  const setEmulatorPath = useCallback(
+    (emulatorPath: string) =>
+      setGlobalSettings((oldGlobalSettings) => ({
+        ...oldGlobalSettings,
+        emulatorPath,
+      })),
+    [setGlobalSettings]
+  );
+
+  const setEmulatorArguments = useCallback(
+    (emulatorArguments: string) =>
+      setGlobalSettings((oldGlobalSettings) => ({
+        ...oldGlobalSettings,
+        emulatorArguments,
+      })),
+    [setGlobalSettings]
+  );
+
   return [
     globalSettings,
     {
@@ -168,6 +192,8 @@ export const useGlobalSettings = (): [
       setAskForConfirmationBeforeRemovingGame,
       setOpenHackFolderAfterDownload,
       setCookie,
+      setEmulatorPath,
+      setEmulatorArguments,
     },
   ];
 };

--- a/src/windows/store.ts
+++ b/src/windows/store.ts
@@ -19,7 +19,7 @@ const GlobalSettingsSchema = z.object({
   openHackFolderAfterDownload: z.boolean(),
   cookie: z.string(),
   emulatorPath: z.string(),
-  emulatorArguments: z.string(),
+  emulatorArgs: z.string(),
 });
 
 const GameSchema = z.object({
@@ -62,7 +62,7 @@ const defaultGlobalSettings = {
   openHackFolderAfterDownload: false,
   cookie: "",
   emulatorPath: "",
-  emulatorArguments: "",
+  emulatorArgs: "",
 };
 
 const globalSettingsState = atom<GlobalSettings>({
@@ -125,7 +125,7 @@ export const useGlobalSettings = (): [
     setOpenHackFolderAfterDownload: (value: boolean) => void;
     setCookie: (value: string) => void;
     setEmulatorPath: (value: string) => void;
-    setEmulatorArguments: (value: string) => void;
+    setEmulatorArgs: (value: string) => void;
   }
 ] => {
   const [globalSettings, setGlobalSettings] =
@@ -176,11 +176,11 @@ export const useGlobalSettings = (): [
     [setGlobalSettings]
   );
 
-  const setEmulatorArguments = useCallback(
-    (emulatorArguments: string) =>
+  const setEmulatorArgs = useCallback(
+    (emulatorArgs: string) =>
       setGlobalSettings((oldGlobalSettings) => ({
         ...oldGlobalSettings,
-        emulatorArguments,
+        emulatorArgs,
       })),
     [setGlobalSettings]
   );
@@ -193,7 +193,7 @@ export const useGlobalSettings = (): [
       setOpenHackFolderAfterDownload,
       setCookie,
       setEmulatorPath,
-      setEmulatorArguments,
+      setEmulatorArgs,
     },
   ];
 };

--- a/src/windows/store.ts
+++ b/src/windows/store.ts
@@ -62,7 +62,7 @@ const defaultGlobalSettings = {
   openHackFolderAfterDownload: false,
   cookie: "",
   emulatorPath: "",
-  emulatorArgs: "",
+  emulatorArgs: "%1",
 };
 
 const globalSettingsState = atom<GlobalSettings>({


### PR DESCRIPTION
This pull request introduces the feature to setup emulators and providing command line arguments.

Additions:
- New section in the settings page with the necessary input fields

Changes:
- If an emulator path is chosen the app will use the new function to read out the emulator path and command line arguments and launch the specified emulator. However if none is selected, the app will still use the default app on your system.

Testing:
- Tested on a Windows 11 machine. Further testing on Mac potentially necessary.