### PR TITLE
fix: creating folder before trying to enter it

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,6 +4,7 @@ DIRPATH="./rom-hack-manager_${VERSION}_macos"
 
 npm run tauri build -- --target=universal-apple-darwin
 
+mkdir -p "./releases"
 cd "./releases"
 
 if [ -d $DIRPATH ]; then rm -rf $DIRPATH; fi


### PR DESCRIPTION
this makes sure the releases folder does exist before trying to cd into it, so this script works in a fresh environment.