### PR TITLE
Support local zip files

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,10 @@ itself (under the _Settings_ section, collapsed by default).
 
 To download (and patch) a hack, you have to specify:
 
-- _Name_: A name of your choosing (usually the name of the hack). This will be
-  the name of the folder created by the tool inside the game folder.
+- _Name_ (optional): A name of your choosing (usually the name of the hack).
+  This will be the name of the folder created by the tool inside the game
+  folder. If left empty, the tool will use the zip file name (without
+  extension).
 - _Download URL or local zip path_: Either a URL for downloading the zip file
   (for example, from SMWCentral) or a path to a local .zip file. On macOS and
   Linux you can use `~` as a shortcut for your home directory (for example:
@@ -111,7 +113,7 @@ You can also look for a game present on SMWCentral directly from within the tool
 You can look for _Super Mario World_ and _Yoshi Island_ hacks.
 
 The tool will download the zip file from the given URL or use the specified
-local zip file, extract it inside a folder of the chosen name
+local zip file, extract it inside a folder of the chosen or derived name
 (`<game_folder>/<hack_name>`), and it will patch the first `.bps` file it
 finds.
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ Do this only if you trust me :)
 With _ROM Hack Manager_ you can:
 
 - **Manage hacks:** The tool will list SNES ROM hacks for selected games.
-- **Download hacks:** Download, unzip, and patch hacks automatically. You can
-  search _Super Mario World_ and _Yoshi Island_ hacks on SMWCentral's catalogue
-  directly from within the tool.
+- **Download hacks:** Download, unzip, and patch hacks automatically from
+  remote URLs or local zip files. You can search _Super Mario World_ and
+  _Yoshi Island_ hacks on SMWCentral's catalogue directly from within the tool.
 
 You can check the [changelog](./CHANGELOG.txt) for an exhaustive list of changes
 for every version.
@@ -93,8 +93,10 @@ To download (and patch) a hack, you have to specify:
 
 - _Name_: A name of your choosing (usually the name of the hack). This will be
   the name of the folder created by the tool inside the game folder.
-- _Download URL_: URL for downloading the zip file. For example, you can find
-  this URL on SMWCentral.
+- _Download URL or local zip path_: Either a URL for downloading the zip file
+  (for example, from SMWCentral) or a path to a local .zip file. On macOS and
+  Linux you can use `~` as a shortcut for your home directory (for example:
+  `~/Downloads/hack.zip`).
 
 | <img src="./docs/images/download_hack.gif" alt="Download a hack manually" width="400px" max-width="100%" style="border: 1px solid black; border-radius: 10px;" /> |
 | :---------------------------------------------------------------------------------------------------------------------------------------------------------------: |
@@ -108,9 +110,10 @@ You can also look for a game present on SMWCentral directly from within the tool
 
 You can look for _Super Mario World_ and _Yoshi Island_ hacks.
 
-The tool will download the zip file from the given URL, extract it inside a
-folder of the chosen name (`<game_folder>/<hack_name>`), and it will patch the
-first `.bps` file it finds.
+The tool will download the zip file from the given URL or use the specified
+local zip file, extract it inside a folder of the chosen name
+(`<game_folder>/<hack_name>`), and it will patch the first `.bps` file it
+finds.
 
 If the URL doesn't download a zip, or if the zip doesn't contain a `.bps` file,
 the operation will fail.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3687,6 +3687,7 @@ dependencies = [
  "tauri-plugin-http",
  "tauri-plugin-opener",
  "tauri-plugin-window-state",
+ "urlencoding",
  "zip-extract",
 ]
 
@@ -5195,6 +5196,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ tauri-plugin-http = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-window-state = { version = "2" }
 zip-extract = "0.1.2"
+urlencoding = "2"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -173,9 +173,40 @@ async fn download_hack(
   // Build paths
   let expanded_game_directory = expand_tilde(game_directory);
   let expanded_game_original_copy = expand_tilde(game_original_copy);
-  let hack_directory_path = PathBuf::from(&expanded_game_directory).join(hack_name);
 
   let is_remote = hack_download_url.starts_with("http://") || hack_download_url.starts_with("https://");
+
+  let effective_hack_name = if hack_name.trim().is_empty() {
+    if is_remote {
+      let without_query = hack_download_url.split('?').next().unwrap_or(hack_download_url);
+      let last_segment = without_query.rsplit('/').next().unwrap_or("hack");
+      let stem = Path::new(last_segment)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("hack");
+      if stem.is_empty() {
+        "hack".to_string()
+      } else {
+        stem.to_string()
+      }
+    } else {
+      let expanded_hack_download_url = expand_tilde(hack_download_url);
+      let local_path = Path::new(&expanded_hack_download_url);
+      let stem = local_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("hack");
+      if stem.is_empty() {
+        "hack".to_string()
+      } else {
+        stem.to_string()
+      }
+    }
+  } else {
+    hack_name.to_string()
+  };
+
+  let hack_directory_path = PathBuf::from(&expanded_game_directory).join(&effective_hack_name);
 
   if is_remote {
     // Validate URL

--- a/src/windows/main/SectionHackDownload.tsx
+++ b/src/windows/main/SectionHackDownload.tsx
@@ -18,7 +18,7 @@ import {
   validateDirectoryPath,
   validateFilePath,
   validateName,
-  validateURL,
+  validateHackDownloadSource,
 } from "../validation";
 
 type SectionHackDownloadProps = {
@@ -54,7 +54,7 @@ function SectionHackDownload({ gameId }: SectionHackDownloadProps) {
   const hackDownloadUrl = useFormValue(gameId, gameDownloadData.downloadUrl, {
     isDirty: gameDownloadData.downloadUrl !== "",
     onChange: gameDownloadDataMethods.setDownloadUrl,
-    validate: validateURL,
+    validate: validateHackDownloadSource,
   });
 
   const handleHackNameChangeValue = hackName.handleChangeValue;
@@ -162,7 +162,7 @@ function SectionHackDownload({ gameId }: SectionHackDownloadProps) {
           onBlur={hackDownloadUrl.handleBlur}
           onChange={hackDownloadUrl.handleChangeValue}
           onSubmit={downloadHackIfIsValid}
-          placeholder="Hack Download URL"
+          placeholder="Hack Download URL or local .zip path"
           value={hackDownloadUrl.value}
         />
         <Flex gap={3}>

--- a/src/windows/main/SectionHackDownload.tsx
+++ b/src/windows/main/SectionHackDownload.tsx
@@ -19,6 +19,7 @@ import {
   validateFilePath,
   validateName,
   validateHackDownloadSource,
+  validateHackNameOrEmpty,
 } from "../validation";
 
 type SectionHackDownloadProps = {
@@ -48,7 +49,7 @@ function SectionHackDownload({ gameId }: SectionHackDownloadProps) {
   const hackName = useFormValue(gameId, gameDownloadData.name, {
     isDirty: gameDownloadData.name !== "",
     onChange: gameDownloadDataMethods.setName,
-    validate: validateName,
+    validate: validateHackNameOrEmpty,
   });
 
   const hackDownloadUrl = useFormValue(gameId, gameDownloadData.downloadUrl, {

--- a/src/windows/validation.ts
+++ b/src/windows/validation.ts
@@ -49,3 +49,13 @@ export const validateHackDownloadSource = async (
 
   return validateFilePath(trimmed);
 };
+
+export const validateHackNameOrEmpty = async (
+  name: string
+): Promise<string | undefined> => {
+  if (name.trim() === "") {
+    return undefined;
+  }
+
+  return validateName(name);
+};

--- a/src/windows/validation.ts
+++ b/src/windows/validation.ts
@@ -33,3 +33,19 @@ export const validateURL = async (url: string): Promise<string | undefined> => {
     .then(() => undefined)
     .catch((e) => e);
 };
+
+export const validateHackDownloadSource = async (
+  value: string
+): Promise<string | undefined> => {
+  const trimmed = value.trim();
+
+  if (trimmed === "") {
+    return "Value cannot be empty";
+  }
+
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+    return validateURL(trimmed);
+  }
+
+  return validateFilePath(trimmed);
+};


### PR DESCRIPTION
This PR adds support for local .zip files. Great for hack that don't originate from smw central and use google drive or other annoying to download from sites. Also great if one has a local collection of hacks.

This also makes the Hack name an optional field. If the field is empty the name will be derived from the .zip file name. The name will be url decoded, so that %20 will be converted to a space character. 

I know this is 2 features in one PR, but one build upon the other. So it's easier this way. But it could probably split up with a bit more work if neccessary. 