### PR TITLE
feat: support for multiple patch files per hack (variants)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,9 @@ You can also look for a game present on SMWCentral directly from within the tool
 You can look for _Super Mario World_ and _Yoshi Island_ hacks.
 
 The tool will download the zip file from the given URL, extract it inside a
-folder of the chosen name (`<game_folder>/<hack_name>`), and it will patch the
-first `.bps` file it finds.
+folder of the chosen name (`<game_folder>/<hack_name>`), and it will patch each `.bps` file it finds.
 
-If the URL doesn't download a zip, or if the zip doesn't contain a `.bps` file,
+If the URL doesn't download a zip, or if the zip doesn't contain any `.bps` files,
 the operation will fail.
 
 After you download a hack, you'll have to wait a few seconds for it to appear in
@@ -128,11 +127,13 @@ The tool provides the following operations on hacks
 
 - **Play:** The tool opens the `.sfc` file of the hack with its default
   application (it should be an emulator). You can specify the default app on you
-  operating system. If the hack has more than one `.sfc` file, the tool will
-  play the one that you see in the table (you cannot control which one).
-- **Open folder:** Open the folder containing the hack.
-- **Delete:** Delete the hack. This deletes the folder of the hack and all its
-  contents.
+  operating system. If the hack has more than one `.sfc` file, each of them will
+  appear as a separate row in the list, and **Play** will open the selected
+  `.sfc` file.
+- **Open folder:** Open the folder containing the hack. This action is shown
+  once per hack.
+- **Delete:** Delete the selected `.sfc` file. If there are no `.sfc` files left
+  in the folder, the tool will delete the folder and all its remaining contents.
 
 | <img src="./docs/images/play_hack.gif" alt="Hack list" width="400px" max-width="100%" /> |
 | :--------------------------------------------------------------------------------------: |


### PR DESCRIPTION
This allows for multiple patch files in one Hack (.zip file). The tool already patched every .bps and created multiple .sfc files, but it only showed one file. Now each .sfc will be shown. 
If there is only one .sfc file the buttons will behave as before.
If there are multiple .sfc files in a hack, the delete button will only the delete that one .sfc file where the user clicked the delete button. 
The directory button is only shown once per hack.
Also the hack name is only shown once per hack.

This is how it looks (check the "Crash Bandicoot and the Retro Dimension" hack)

![Bildschirmfoto_2025-12-08_um_20 42 26](https://github.com/user-attachments/assets/13826bc5-b081-4a55-b0c1-9a1c1b741031)
